### PR TITLE
fix: get correct scrollTop value in scroll event

### DIFF
--- a/src/mode/slide/core.js
+++ b/src/mode/slide/core.js
@@ -92,15 +92,13 @@ export default {
       };
     },
     emitEvent(eventType, nativeEvent = null) {
-      let { scrollTop, scrollLeft } = this.scrollPanelElm;
-
       const vertical = {
         type: 'vertical'
       };
       const horizontal = {
         type: 'horizontal'
       };
-
+      const { scrollTop, scrollLeft } = this.getPosition();
       const { v, h } = this.getScrollProcess();
 
       vertical.process = v;


### PR DESCRIPTION
fix #236 